### PR TITLE
Feat: follow&unfollow (follow testing NOT passed)

### DIFF
--- a/controllers/followshipController.js
+++ b/controllers/followshipController.js
@@ -1,0 +1,53 @@
+const { Followship, User } = require('../models')
+
+const helpers = require('../_helpers')
+
+module.exports = {
+  createFollowship: async (req, res, next) => {
+    try {
+      const id = req.body.id
+      if (String(id) === String(helpers.getUser(req).id)) {
+        return res.json({ status: 'error', message: '不能追蹤自己' })
+      }
+      const user = await User.findByPk(id)
+      if (!user) {
+        return res.json({ status: 'error', message: '找不到使用者' })
+      }
+      const followship = await Followship.findOne({
+        where: { followerId: helpers.getUser(req).id, followingId: user.id }
+      })
+      if (followship) {
+        return res.json({ status: 'error', message: '操作重複' })
+      }
+      await Followship.create({ followerId: helpers.getUser(req).id, followingId: user.id })
+      return res.json({
+        status: 'success',
+        message: '追蹤成功'
+      })
+    } catch (err) {
+      next(err)
+    }
+  },
+  deleteFollowship: async (req, res, next) => {
+    try {
+      const id = req.params.id
+      const user = await User.findByPk(id)
+      if (!user) {
+        return res.json({ status: 'error', message: '找不到使用者' })
+      }
+      const followship = await Followship.findOne({
+        where: { followerId: helpers.getUser(req).id, followingId: user.id }
+      })
+      if (!followship) {
+        return res.json({ status: 'error', message: '找不到追蹤紀錄' })
+      }
+      await followship.destroy()
+      return res.json({
+        status: 'success',
+        message: '取消追蹤成功'
+      })
+    } catch (err) {
+      next(err)
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=development node app.js",
-    "dev": "NODE_ENV=development nodemon app.js",
+    "start": "set \"NODE_ENV=development\" && node app.js",
+    "dev": "set \"NODE_ENV=development\" && nodemon app.js",
     "test": "mocha test --exit --recursive --timeout 5000"
   },
   "author": "",

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,6 +13,11 @@ const { authToken, authUserRole, authAdminRole } = require('../middleware/auth')
 
 //routes
 
+
+//followship
+router.post('/api/followships', authToken, authUserRole, followshipController.createFollowship)
+router.delete('/api/followships/:id', authToken, authUserRole, followshipController.deleteFollowship)
+
 //users
 router.post('/api/login', userController.login)
 router.post('/api/users', userController.createUser)


### PR DESCRIPTION
這個分支是關於 followship 的功能，但是我跑測試時，第一個路由 POST /api/followships 會跑不過。
是一個超怪的原因... 我目前找不到，好像是 followship.spec.js 測試檔在find 建立完的 Followship 時會找不到
`db.Followship.findByPk(1).then(followship => {
    followship.followerId.should.equal(1);
    followship.followingId.should.equal(2);
    return done();
  })`
錯誤圖片:
![error](https://user-images.githubusercontent.com/61738331/102448420-0d149e00-406d-11eb-9e52-a1252c9ad046.png)

有空的話幫我看一下，或是來討論，感謝~
